### PR TITLE
Corregir requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django   5.1.3
+Django==5.1.3


### PR DESCRIPTION
Al tratar de instalar requirements con pip daba error debido a como estaba escrito, con el cambio que se hizo ya es posible instalar requirements.